### PR TITLE
Unsafe fonts

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -59,7 +59,7 @@
   </div>
 
   <script type="text/javascript"
-    src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML">
+    src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.4/MathJax.js?config=TeX-AMS-MML_HTMLorMML">
   </script>
 
 </footer>

--- a/_sass/_vars.scss
+++ b/_sass/_vars.scss
@@ -1,6 +1,6 @@
 @charset "utf-8";
-@import url(http://fonts.googleapis.com/css?family=Source+Code+Pro:400,700);
-@import url(http://fonts.googleapis.com/css?family=Open+Sans:400,300,700);
+@import url(https://fonts.googleapis.com/css?family=Source+Code+Pro:400,700);
+@import url(https://fonts.googleapis.com/css?family=Open+Sans:400,300,700);
 
 $base-font-family: "Open Sans", Helvetica, Arial, sans-serif;
 $base-font-size:   16px;


### PR DESCRIPTION
Changed unsafe font includes and changed the cdn for mathjax to cdnjs after discontinuation of cdn.mathjax.